### PR TITLE
Add support for cloud snapshot testing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ WORKDIR /
 COPY config /config
 COPY run.sh /run.sh
 COPY specs /specs
+COPY cloud-snap-specs /cloud-snap-specs
 
 RUN apt-get update; apt-get install -y curl  
 RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl

--- a/cloud-snap-specs/snapshotclass.yaml
+++ b/cloud-snap-specs/snapshotclass.yaml
@@ -1,0 +1,10 @@
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshotClass
+metadata:
+  name: px-csi-snapclass
+  annotations:
+    snapshot.storage.kubernetes.io/is-default-class: "true"
+driver: pxd.portworx.com
+deletionPolicy: Delete
+parameters:
+  csi.openstorage.org/snapshot-type: "cloud"

--- a/cloud-snap-specs/storageclass.yaml
+++ b/cloud-snap-specs/storageclass.yaml
@@ -1,0 +1,11 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+    name: portworx-sc
+    annotations:
+        storageclass.kubernetes.io/is-default-class: "true"
+provisioner: pxd.portworx.com
+allowVolumeExpansion: true
+parameters:
+    repl: "3"
+    io_profile: "db"

--- a/run.sh
+++ b/run.sh
@@ -4,7 +4,7 @@
 K8S_E2E_TEST_PATH=$PWD/e2e.test
 REPORTS_DIR=reports
 LOGS_DIR=/logs
-SPECS_DIR=/specs
+SPECS_DIR="${SPECS_DIR_OVERRIDE:=/specs}"
 SKIP_PATTERN="\[Disruptive\]"
 
 # Configurable


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

This PR makes necessary change to run Cloud Snapshots as well in addition to local snapshots while running Kubernetes conformance tests. The change has been made in such a way that existing jobs wont be affected, a new job will be created which will use the files in the new directory.

**Which issue(s) this PR fixes** (optional)
Closes #PWX-30554

**Special notes for your reviewer**:

